### PR TITLE
Fix: Modify GetDetailedTooltip to use vanila ItemPrefab.GetTooltip

### DIFF
--- a/ClientProject/ClientSource/CardBuilder.cs
+++ b/ClientProject/ClientSource/CardBuilder.cs
@@ -21,33 +21,21 @@ namespace SOS
 
         private static readonly Dictionary<Identifier, string> machineNameCache = [];
 
-        public static RichString GetDetailedTooltip(ItemPrefab prefab)
+        public static RichString GetDetailedTooltip(ItemPrefab? prefab)
         {
-            if (prefab == null) return RichString.Rich("");
+            LocalizedString actual = prefab?.GetTooltip(Character.Controlled) ?? "";
+            ReadOnlySpan<char> value = actual.Value.AsSpan();
+            int idx = value.LastIndexOf('\n');
+            ReadOnlySpan<char> modLine = idx == -1 ? value : value[(idx + 1)..];
 
-            string toolTip = $"‖color:White‖{prefab.Name.Value}‖color:end‖";
-
-#if DEBUG
-            toolTip += $" ‖color:gui.orange‖({prefab.Identifier})‖color:end‖";
-#endif
-
-            int price = prefab.DefaultPrice?.Price ?? 0;
-            if (price > 0)
+            if (prefab?.ContentPackage != null)
             {
-                toolTip += $"\n‖color:{Color.Gold.ToStringHex()}‖{TextSOS.Get("sos.item.price", "Price")}{price}mk‖color:end‖";
-            }
+                if (modLine.Equals(prefab.ContentPackage.Name, StringComparison.Ordinal)) return RichString.Rich(actual);
 
-            if (!prefab.Description.IsNullOrEmpty())
-            {
-                toolTip += "\n" + prefab.Description.Value;
-            }
-            if (prefab.ContentPackage != null && prefab.ContentPackage.Name != "Vanilla")
-            {
                 string modColor = XMLExtensions.ToStringHex(Color.MediumPurple);
-                toolTip += $"\n‖color:{modColor}‖{prefab.ContentPackage.Name}‖color:end‖";
+                actual += $"\n‖color:{modColor}‖{prefab.ContentPackage.Name}‖color:end‖";
             }
-
-            return RichString.Rich(toolTip);
+            return RichString.Rich(actual);
         }
 
         public static void DrawHeader(GUIFrame parent, ItemPrefab item)
@@ -325,7 +313,7 @@ namespace SOS
 
             var btn = new GUIButton(btnRect, style: "GUIButton")
             {
-                ToolTip = prefab != null ? GetDetailedTooltip(prefab) : null,
+                ToolTip = GetDetailedTooltip(prefab),
                 Color = Color.Black * 0.4f
             };
 
@@ -390,7 +378,7 @@ namespace SOS
                 {
                     AbsoluteSpacing = 5,
                     CanBeFocused = true,
-                    ToolTip = prefab != null ? GetDetailedTooltip(prefab) : null
+                    ToolTip = GetDetailedTooltip(prefab)
                 };
             }
 

--- a/ClientProject/ClientSource/ItemSections.cs
+++ b/ClientProject/ClientSource/ItemSections.cs
@@ -93,7 +93,7 @@ namespace SOS
         public void AddFullWidthText(string text, Color color)
         {
             if (currentLayout == null || string.IsNullOrEmpty(text)) return;
-            var block = new GUITextBlock(new RectTransform(new Vector2(1f, 0f), currentLayout.RectTransform), text, font: GUIStyle.SmallFont, textColor: color, wrap: true) { CanBeFocused = false };
+            var block = new GUITextBlock(new RectTransform(new Vector2(1f, 0f), currentLayout.RectTransform), RichString.Rich(text), textColor: color, font: GUIStyle.SmallFont, wrap: true) { CanBeFocused = false, };
 
             int textHeight = (int)block.TextSize.Y + 10;
             block.RectTransform.MinSize = new Point(0, textHeight);

--- a/ClientProject/ClientSource/SOSWindow.cs
+++ b/ClientProject/ClientSource/SOSWindow.cs
@@ -301,6 +301,9 @@ namespace SOS
             mainFrame.ForceLayoutRecalculation();
         }
 
+        void OnPrimary(ItemPrefab p) => controller.OnItemSelected(p);
+        void OnSecondary(ItemPrefab p) => controller.OpenContextMenu(p);
+
         public void SetSelected()
         {
             if (mainFrame == null) return;
@@ -419,8 +422,8 @@ namespace SOS
                     }
 
                     CardBuilder.DrawMinimalItemRow(currentRow, prefab, 1,
-                        onPrimaryClick: p => controller.OnItemSelected(p),
-                        onSecondaryClick: p => controller.OpenContextMenu(p),
+                        onPrimaryClick: p => OnPrimary(p),
+                        onSecondaryClick: p => OnSecondary(p),
                         badgeColor: isFav ? Color.Gold : (Color?)null);
 
                     itemsInRow++;
@@ -435,8 +438,8 @@ namespace SOS
 
                     var btn = new GUIButton(new RectTransform(new Vector2(1f, 0f), itemList.Content.RectTransform) { MinSize = new Point(0, 35) }, style: "ListBoxElement")
                     {
-                        OnClicked = (_, _) => { controller.OnItemSelected(prefab); return true; },
-                        OnSecondaryClicked = (_, _) => { controller.OpenContextMenu(prefab); return true; }
+                        OnClicked = (_, _) => { OnPrimary(prefab); return true; },
+                        OnSecondaryClicked = (_, _) => { OnSecondary(prefab); return true; }
                     };
 
                     //string prefix = isFav ? "* " : "";
@@ -640,9 +643,6 @@ namespace SOS
                 CanBeFocused = false
             };
 
-            void onPrimary(ItemPrefab p) => controller.OnItemSelected(p);
-            void onSecondary(ItemPrefab p) => controller.OpenContextMenu(p);
-
             UIMachineGroup GetOrCreateMachineGroup(Dictionary<string, UIMachineGroup> dict, IEnumerable<Identifier> machineIds, string fallbackName)
             {
                 string key = machineIds.Any()
@@ -702,13 +702,13 @@ namespace SOS
             foreach (var r in craft)
             {
                 var mg = GetOrCreateMachineGroup(obtainGroups, r.SuitableFabricatorIdentifiers, TextSOS.Get("sos.recipe.hand", "Hand").Value);
-                mg.AddCard(new CraftRecipeCard(r, targetItem, controller, onPrimary, onSecondary));
+                mg.AddCard(new CraftRecipeCard(r, targetItem, controller, OnPrimary, OnSecondary));
             }
 
             foreach (var src in groupedSources)
             {
                 var mg = GetOrCreateMachineGroup(obtainGroups, src.MachineIds ?? [], ResolveMachineName("deconstructor".ToIdentifier()));
-                mg.AddCard(new SourceRecipeCard(src, onPrimary, onSecondary));
+                mg.AddCard(new SourceRecipeCard(src, OnPrimary, OnSecondary));
             }
 
             foreach (var group in obtainGroups.Values) group.Draw(colObtain);
@@ -730,14 +730,14 @@ namespace SOS
 
                     if (isRandom)
                     {
-                        mg.AddCard(new DeconOutputCard(targetItem, deconList, onPrimary, onSecondary));
+                        mg.AddCard(new DeconOutputCard(targetItem, deconList, OnPrimary, OnSecondary));
                     }
                     else
                     {
                         var groupedOutputs = deconList.GroupBy(di => di.ItemIdentifier).Select(g => new { ID = g.Key, Amount = g.Max(di => di.Amount), Weight = g.Sum(di => di.Commonness) });
                         foreach (var output in groupedOutputs)
                         {
-                            mg.AddCard(new SingleDeconOutputCard(targetItem, output.ID, output.Amount, output.Weight, onPrimary, onSecondary));
+                            mg.AddCard(new SingleDeconOutputCard(targetItem, output.ID, output.Amount, output.Weight, OnPrimary, OnSecondary));
                         }
                     }
                 }
@@ -746,7 +746,7 @@ namespace SOS
             foreach (var usage in groupedUses)
             {
                 var mg = GetOrCreateMachineGroup(usageDict, usage.MachineIds ?? [], TextSOS.Get("sos.recipe.hand", "Hand").Value);
-                mg.AddCard(new UsageRecipeCard(usage, onPrimary, onSecondary));
+                mg.AddCard(new UsageRecipeCard(usage, OnPrimary, OnSecondary));
             }
 
             foreach (var group in usageDict.Values) group.Draw(colUsage);
@@ -757,10 +757,10 @@ namespace SOS
             var builder = new SectionBuilder
             (
                 metaPanel,
-onBadgeClick,
+                onBadgeClick,
                 controller,
-onPrimary,
-onSecondary
+                OnPrimary,
+                OnSecondary
             );
 
             var analysis = RecipeAnalyzer.GetAnalysis(targetItem);


### PR DESCRIPTION
Fix: Modified GetDetailedTooltip to accept optional values ​​and use the ItemPrefab.GetTooltip method to retrieve the correct current string—even if it has been modified by other mods.
Fix: Use RichString instead of string for long text fields (such as Description).
Chore: Minor code changes that do not affect gameplay but improve overall optimization.