### PR TITLE
Adjustments to enable minimum mod functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,4 @@ FodyWeavers.xsd
 
 # Extra unnecesary files
 SOS*.txt
+Build.props

--- a/ClientProject/ClientSource/Plugin.cs
+++ b/ClientProject/ClientSource/Plugin.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for details.
 
 using Barotrauma;
+using Barotrauma.LuaCs;
+using static Barotrauma.LuaCs.ILuaEventService;
+using Barotrauma.LuaCs.Compatibility;
 
 namespace SOS
 {
@@ -47,7 +50,7 @@ namespace SOS
             });
 #endif
 
-            GameMain.LuaCs.Hook.Add("keyupdate", "SOS_UpdateLoop", _ =>
+            LuaCsSetup.Instance.EventService.Add("think", "SOS_UpdateLoop", _ =>
             {
                 controller?.Update();
 #if DEBUG
@@ -67,7 +70,7 @@ namespace SOS
         public void DisposeClient()
         {
             DebugConsole.commands.RemoveAll(c => c.Names.Contains("sos"));
-            GameMain.LuaCs.Hook.Remove("keyupdate", "SOS_UpdateLoop");
+            LuaCsSetup.Instance.EventService.Remove("think", "SOS_UpdateLoop");
             controller?.SaveSettings();
             controller?.Destroy();
             controller = null;

--- a/ServerProject/ServerSource/Plugin.cs
+++ b/ServerProject/ServerSource/Plugin.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for details.
 
 using Barotrauma;
+using Barotrauma.LuaCs;
 
 namespace SOS
 {

--- a/SharedProject/SharedSource/Plugin.cs
+++ b/SharedProject/SharedSource/Plugin.cs
@@ -7,6 +7,7 @@
 #pragma warning disable IDE0290
 
 using Barotrauma;
+using Barotrauma.LuaCs;
 
 using System.Runtime.CompilerServices;
 [assembly: IgnoresAccessChecksTo("Barotrauma")]


### PR DESCRIPTION
I added a few more references and changed the init hook from `keyupdate` to `think`. The mod compiles, and functions without errors. However, the search bar is virtually useless, so browsing items requires using the other methods. Pressing J when hovering over an item (or shift + J when hovering over a focused item) works, as does clicking the tags on the right side of the screen to filter the item list by tag. It's specifically typing in the searchbar no longer functions.

Without these changes, the mod will still load, but the mod menu does not open when pressing J, and forcing the menu to open via debug command will only give an empty menu.

Compiled mod: 
[SOS_Mod.zip](https://github.com/user-attachments/files/26650011/SOS_Mod.zip)
